### PR TITLE
feat: adds instructions for passing Nift a full set of prepop customer data via an encrypted attribute

### DIFF
--- a/docs/encrypted_customer_data_web_flow.md
+++ b/docs/encrypted_customer_data_web_flow.md
@@ -2,21 +2,21 @@
 
 ## Overview
 
-Partners can pass multiple customer fields in a single encrypted `customer_data` parameter in the Nift card referral link. This is an alternative to passing `email`, `first_name`, `last_name`, and `zipcode` as separate query parameters — instead, all fields are bundled into one encrypted blob.
+Partners can pass multiple customer fields in a single encrypted `enc` parameter in the Nift card referral link. This is an alternative to passing `email`, `first_name`, `last_name`, and `zipcode` as separate query parameters — instead, all fields are bundled into one encrypted blob.
 
 For how to encrypt the value, see [Encrypting Values with AES-256-GCM](encrypting_values.md).
 
 ## URL Format
 
 ```
-https://www.gonift.com/nift_cards/{referral_code}/start?customer_data={encrypted_blob}
+https://www.gonift.com/nift_cards/{referral_code}/start?enc={encrypted_blob}
 ```
 
-The `customer_data` parameter replaces the individual query parameters (`email`, `first_name`, `last_name`, `zipcode`) with a single encrypted value.
+The `enc` parameter replaces the individual query parameters (`email`, `first_name`, `last_name`, `zipcode`) with a single encrypted value.
 
 ## Supported Fields
 
-The plaintext JSON inside the encrypted `customer_data` blob supports these fields:
+The plaintext JSON inside the encrypted `enc` blob supports these fields:
 
 | Field | Required | Description |
 |-------|----------|-------------|
@@ -31,7 +31,7 @@ All fields are optional — include whichever fields you have available. Unknown
 
 1. Build a JSON object containing the customer fields you want to send
 2. Encrypt the JSON string using the process described in [Encrypting Values](encrypting_values.md)
-3. Pass the encrypted value as the `customer_data` query parameter
+3. Pass the encrypted value as the `enc` query parameter
 
 ### Step 1: Build the plaintext JSON
 
@@ -51,17 +51,17 @@ Use the same AES-256-GCM encryption process described in [Encrypting Values](enc
 ### Step 3: Pass the encrypted value in the URL
 
 ```
-https://www.gonift.com/nift_cards/MYCODE123/start?customer_data=eyJpdiI6Ii4uLiIsImNpcGhlcnRleHQiOiIuLi4iLCJ0YWciOiIuLi4ifQ
+https://www.gonift.com/nift_cards/MYCODE123/start?enc=eyJpdiI6Ii4uLiIsImNpcGhlcnRleHQiOiIuLi4iLCJ0YWciOiIuLi4ifQ
 ```
 
 Since the output is Base64url-encoded (using only `A-Z`, `a-z`, `0-9`, `-`, `_`), it is safe to include directly in a URL query string without additional percent-encoding.
 
 ## Parameter Precedence
 
-Individual query parameters take precedence over fields in `customer_data`. If you pass both `customer_data` and a standalone parameter, the standalone parameter wins:
+Individual query parameters take precedence over fields in `enc`. If you pass both `enc` and a standalone parameter, the standalone parameter wins:
 
 ```
-?customer_data={blob containing first_name: "Jane"}&first_name=Janet
+?enc={blob containing first_name: "Jane"}&first_name=Janet
 ```
 
 In this example, `first_name` will be `"Janet"`, not `"Jane"`.
@@ -70,10 +70,10 @@ This allows you to encrypt most fields while still overriding specific values as
 
 ## Examples
 
-### All fields in customer_data
+### All fields in enc
 
 ```
-https://www.gonift.com/nift_cards/MYCODE123/start?customer_data=eyJpdiI6Ii4uLiIsImNpcGhlcnRleHQiOiIuLi4iLCJ0YWciOiIuLi4ifQ
+https://www.gonift.com/nift_cards/MYCODE123/start?enc=eyJpdiI6Ii4uLiIsImNpcGhlcnRleHQiOiIuLi4iLCJ0YWciOiIuLi4ifQ
 ```
 
 ### Partial fields (email only)
@@ -86,10 +86,10 @@ If you only have the customer's email, the plaintext JSON would be:
 }
 ```
 
-### Mixed: customer_data with individual overrides
+### Mixed: enc with individual overrides
 
 ```
-https://www.gonift.com/nift_cards/MYCODE123/start?customer_data=eyJpdiI6Ii4uLiIsImNpcGhlcnRleHQiOiIuLi4iLCJ0YWciOiIuLi4ifQ&first_name=Janet
+https://www.gonift.com/nift_cards/MYCODE123/start?enc=eyJpdiI6Ii4uLiIsImNpcGhlcnRleHQiOiIuLi4iLCJ0YWciOiIuLi4ifQ&first_name=Janet
 ```
 
 Here, `first_name` from the query string overrides whatever `first_name` was inside the encrypted blob.
@@ -105,7 +105,7 @@ The behavior when the customer lands on this URL depends on how the referral cod
 
 ## Comparison with Individual Encrypted Parameters
 
-| | `customer_data` | Individual `email` param |
+| | `enc` | Individual `email` param |
 |--|-----------------|--------------------------|
 | **What's encrypted** | JSON object with multiple fields | Single email value |
 | **Plaintext detection** | Not supported — value is always treated as encrypted | If value contains `@`, treated as plaintext email |

--- a/docs/encrypted_customer_data_web_flow.md
+++ b/docs/encrypted_customer_data_web_flow.md
@@ -23,7 +23,7 @@ The plaintext JSON inside the encrypted `customer_data` blob supports these fiel
 | `email` | No | Customer's email address |
 | `first_name` | No | Customer's first name |
 | `last_name` | No | Customer's last name |
-| `postal_code` | No | Customer's postal/zip code |
+| `zipcode` | No | Customer's postal/zip code |
 
 All fields are optional — include whichever fields you have available. Unknown fields are ignored.
 
@@ -40,13 +40,13 @@ All fields are optional — include whichever fields you have available. Unknown
   "email": "jane@example.com",
   "first_name": "Jane",
   "last_name": "Doe",
-  "postal_code": "02116"
+  "zipcode": "02116"
 }
 ```
 
 ### Step 2: Encrypt the JSON string
 
-Use the same AES-256-GCM encryption process described in [Encrypting Values](encrypting_values.md). The **plaintext** input is the JSON string from step 1 (e.g., `"{\"email\":\"jane@example.com\",\"first_name\":\"Jane\",\"last_name\":\"Doe\",\"postal_code\":\"02116\"}"`).
+Use the same AES-256-GCM encryption process described in [Encrypting Values](encrypting_values.md). The **plaintext** input is the JSON string from step 1 (e.g., `"{\"email\":\"jane@example.com\",\"first_name\":\"Jane\",\"last_name\":\"Doe\",\"zipcode\":\"02116\"}"`).
 
 ### Step 3: Pass the encrypted value in the URL
 
@@ -110,6 +110,6 @@ The behavior when the customer lands on this URL depends on how the referral cod
 | **What's encrypted** | JSON object with multiple fields | Single email value |
 | **Plaintext detection** | Not supported — value is always treated as encrypted | If value contains `@`, treated as plaintext email |
 | **Number of encrypted params** | One blob for all fields | One per encrypted field |
-| **Supported fields** | `email`, `first_name`, `last_name`, `postal_code` | `email` only |
+| **Supported fields** | `email`, `first_name`, `last_name`, `zipcode` | `email` only |
 
 Both approaches can be used alongside each other. See [Encrypted Email in the Nift Web Flow](encrypted_email_web_flow.md) for the individual parameter approach.

--- a/docs/encrypted_customer_data_web_flow.md
+++ b/docs/encrypted_customer_data_web_flow.md
@@ -1,0 +1,115 @@
+# Encrypted Customer Data in the Nift Web Flow
+
+## Overview
+
+Partners can pass multiple customer fields in a single encrypted `customer_data` parameter in the Nift card referral link. This is an alternative to passing `email`, `first_name`, `last_name`, and `zipcode` as separate query parameters — instead, all fields are bundled into one encrypted blob.
+
+For how to encrypt the value, see [Encrypting Values with AES-256-GCM](encrypting_values.md).
+
+## URL Format
+
+```
+https://www.gonift.com/nift_cards/{referral_code}/start?customer_data={encrypted_blob}
+```
+
+The `customer_data` parameter replaces the individual query parameters (`email`, `first_name`, `last_name`, `zipcode`) with a single encrypted value.
+
+## Supported Fields
+
+The plaintext JSON inside the encrypted `customer_data` blob supports these fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `email` | No | Customer's email address |
+| `first_name` | No | Customer's first name |
+| `last_name` | No | Customer's last name |
+| `postal_code` | No | Customer's postal/zip code |
+
+All fields are optional — include whichever fields you have available. Unknown fields are ignored.
+
+## How It Works
+
+1. Build a JSON object containing the customer fields you want to send
+2. Encrypt the JSON string using the process described in [Encrypting Values](encrypting_values.md)
+3. Pass the encrypted value as the `customer_data` query parameter
+
+### Step 1: Build the plaintext JSON
+
+```json
+{
+  "email": "jane@example.com",
+  "first_name": "Jane",
+  "last_name": "Doe",
+  "postal_code": "02116"
+}
+```
+
+### Step 2: Encrypt the JSON string
+
+Use the same AES-256-GCM encryption process described in [Encrypting Values](encrypting_values.md). The **plaintext** input is the JSON string from step 1 (e.g., `"{\"email\":\"jane@example.com\",\"first_name\":\"Jane\",\"last_name\":\"Doe\",\"postal_code\":\"02116\"}"`).
+
+### Step 3: Pass the encrypted value in the URL
+
+```
+https://www.gonift.com/nift_cards/MYCODE123/start?customer_data=eyJpdiI6Ii4uLiIsImNpcGhlcnRleHQiOiIuLi4iLCJ0YWciOiIuLi4ifQ
+```
+
+Since the output is Base64url-encoded (using only `A-Z`, `a-z`, `0-9`, `-`, `_`), it is safe to include directly in a URL query string without additional percent-encoding.
+
+## Parameter Precedence
+
+Individual query parameters take precedence over fields in `customer_data`. If you pass both `customer_data` and a standalone parameter, the standalone parameter wins:
+
+```
+?customer_data={blob containing first_name: "Jane"}&first_name=Janet
+```
+
+In this example, `first_name` will be `"Janet"`, not `"Jane"`.
+
+This allows you to encrypt most fields while still overriding specific values as needed.
+
+## Examples
+
+### All fields in customer_data
+
+```
+https://www.gonift.com/nift_cards/MYCODE123/start?customer_data=eyJpdiI6Ii4uLiIsImNpcGhlcnRleHQiOiIuLi4iLCJ0YWciOiIuLi4ifQ
+```
+
+### Partial fields (email only)
+
+If you only have the customer's email, the plaintext JSON would be:
+
+```json
+{
+  "email": "jane@example.com"
+}
+```
+
+### Mixed: customer_data with individual overrides
+
+```
+https://www.gonift.com/nift_cards/MYCODE123/start?customer_data=eyJpdiI6Ii4uLiIsImNpcGhlcnRleHQiOiIuLi4iLCJ0YWciOiIuLi4ifQ&first_name=Janet
+```
+
+Here, `first_name` from the query string overrides whatever `first_name` was inside the encrypted blob.
+
+## Behavior
+
+The behavior when the customer lands on this URL depends on how the referral code is configured:
+
+| Referral Code Type | What Happens |
+|--------------------|-------------|
+| **skip-details enabled** | The nift card is **automatically activated** using the provided parameters. The customer skips the details form entirely and goes straight to browsing gift categories. |
+| **standard (skip-details disabled)** | The provided parameters **pre-fill the details form**. The customer still reviews and submits the form before the nift card is activated. |
+
+## Comparison with Individual Encrypted Parameters
+
+| | `customer_data` | Individual `email` param |
+|--|-----------------|--------------------------|
+| **What's encrypted** | JSON object with multiple fields | Single email value |
+| **Plaintext detection** | Not supported — value is always treated as encrypted | If value contains `@`, treated as plaintext email |
+| **Number of encrypted params** | One blob for all fields | One per encrypted field |
+| **Supported fields** | `email`, `first_name`, `last_name`, `postal_code` | `email` only |
+
+Both approaches can be used alongside each other. See [Encrypted Email in the Nift Web Flow](encrypted_email_web_flow.md) for the individual parameter approach.

--- a/docs/encrypted_email_web_flow.md
+++ b/docs/encrypted_email_web_flow.md
@@ -53,4 +53,4 @@ The behavior when the customer lands on this URL depends on how the referral cod
 
 ## Alternative: Encrypted Customer Data
 
-Instead of encrypting just the email and passing other fields as plaintext query parameters, you can bundle all customer fields into a single encrypted `customer_data` parameter. See [Encrypted Customer Data in the Nift Web Flow](encrypted_customer_data_web_flow.md).
+Instead of encrypting just the email and passing other fields as plaintext query parameters, you can bundle all customer fields into a single encrypted `enc` parameter. See [Encrypted Customer Data in the Nift Web Flow](encrypted_customer_data_web_flow.md).

--- a/docs/encrypted_email_web_flow.md
+++ b/docs/encrypted_email_web_flow.md
@@ -50,3 +50,7 @@ The behavior when the customer lands on this URL depends on how the referral cod
 |--------------------|-------------|
 | **skip-details enabled** | The nift card is **automatically activated** using the provided parameters. The customer skips the details form entirely and goes straight to browsing gift categories. |
 | **standard (skip-details disabled)** | The provided parameters **pre-fill the details form**. The customer still reviews and submits the form before the nift card is activated. |
+
+## Alternative: Encrypted Customer Data
+
+Instead of encrypting just the email and passing other fields as plaintext query parameters, you can bundle all customer fields into a single encrypted `customer_data` parameter. See [Encrypted Customer Data in the Nift Web Flow](encrypted_customer_data_web_flow.md).

--- a/docs/encrypting_values.md
+++ b/docs/encrypting_values.md
@@ -2,9 +2,15 @@
 
 ## Overview
 
-To protect sensitive customer data in transit, we support encrypting fields (such as `email`) using **AES-256-GCM** symmetric encryption. This encryption format is used across all Nift integration paths:
+To protect sensitive customer data in transit, we support encrypting fields using **AES-256-GCM** symmetric encryption. You can encrypt:
 
-- [Nift Web Flow](encrypted_email_web_flow.md) — referral links with query parameters
+- A **single value** (e.g., an email address) — passed as the `email` query parameter or SDK field
+- **Multiple customer fields** bundled into a single JSON blob — passed as the `customer_data` query parameter
+
+This encryption format is used across all Nift integration paths:
+
+- [Nift Web Flow — Encrypted Email](encrypted_email_web_flow.md) — single encrypted email via referral links
+- [Nift Web Flow — Encrypted Customer Data](encrypted_customer_data_web_flow.md) — multiple encrypted fields via referral links
 - [Nift SDK](encrypted_email_sdk.md) — SDK initialization
 
 ## What We Provide
@@ -230,10 +236,58 @@ public String encryptValue(String value, String base64Key) throws Exception {
 
 </details>
 
+## Encrypting Multiple Fields (`customer_data`)
+
+The `customer_data` parameter lets you encrypt multiple customer fields in a single blob. The process is the same as above, except the **plaintext** you encrypt is a JSON string instead of a raw value.
+
+### Supported fields
+
+| Field | Description |
+|-------|-------------|
+| `email` | Customer's email address |
+| `first_name` | Customer's first name |
+| `last_name` | Customer's last name |
+| `postal_code` | Customer's postal/zip code |
+
+### Steps
+
+1. Build a JSON object with the customer fields you want to include (all fields are optional):
+
+    ```json
+    {
+      "email": "user@example.com",
+      "first_name": "Jane",
+      "last_name": "Doe",
+      "postal_code": "02116"
+    }
+    ```
+
+2. Treat this JSON **string** as the plaintext and follow the same [encryption steps above](#how-to-encrypt).
+
+3. Pass the result as the `customer_data` query parameter.
+
+For example, using the Python function from the code examples:
+
+```python
+import json
+
+customer_fields = json.dumps({
+    "email": "user@example.com",
+    "first_name": "Jane",
+    "last_name": "Doe",
+    "postal_code": "02116",
+})
+
+encrypted = encrypt_value(customer_fields, base64_key)
+# Use as: ?customer_data={encrypted}
+```
+
+For full usage details, see [Encrypted Customer Data in the Nift Web Flow](encrypted_customer_data_web_flow.md).
+
 ## Important Notes
 
 *   **Never reuse an IV** with the same key. Generate a fresh random 12-byte IV for every encryption.
-*   **Plaintext fallback**: If you send an unencrypted email (containing `@`), it will be accepted as-is. This allows gradual rollout.
+*   **Plaintext fallback (email only)**: If you send an unencrypted email (containing `@`) via the `email` parameter, it will be accepted as-is. This allows gradual rollout. This does **not** apply to `customer_data`, which is always treated as encrypted.
 *   **Plaintext detection**: The `@` character is not part of Base64 or Base64url, so the system reliably distinguishes plaintext email addresses from encrypted blobs by checking for the presence of `@`.
 *   **Tag length**: Always use a 128-bit (16-byte) authentication tag. This is the GCM default and maximum.
 *   **No padding characters**: Base64url encoding should NOT include `=` padding characters.

--- a/docs/encrypting_values.md
+++ b/docs/encrypting_values.md
@@ -247,7 +247,7 @@ The `customer_data` parameter lets you encrypt multiple customer fields in a sin
 | `email` | Customer's email address |
 | `first_name` | Customer's first name |
 | `last_name` | Customer's last name |
-| `postal_code` | Customer's postal/zip code |
+| `zipcode` | Customer's postal/zip code |
 
 ### Steps
 
@@ -258,7 +258,7 @@ The `customer_data` parameter lets you encrypt multiple customer fields in a sin
       "email": "user@example.com",
       "first_name": "Jane",
       "last_name": "Doe",
-      "postal_code": "02116"
+      "zipcode": "02116"
     }
     ```
 
@@ -275,7 +275,7 @@ customer_fields = json.dumps({
     "email": "user@example.com",
     "first_name": "Jane",
     "last_name": "Doe",
-    "postal_code": "02116",
+    "zipcode": "02116",
 })
 
 encrypted = encrypt_value(customer_fields, base64_key)

--- a/docs/encrypting_values.md
+++ b/docs/encrypting_values.md
@@ -5,7 +5,7 @@
 To protect sensitive customer data in transit, we support encrypting fields using **AES-256-GCM** symmetric encryption. You can encrypt:
 
 - A **single value** (e.g., an email address) — passed as the `email` query parameter or SDK field
-- **Multiple customer fields** bundled into a single JSON blob — passed as the `customer_data` query parameter
+- **Multiple customer fields** bundled into a single JSON blob — passed as the `enc` query parameter
 
 This encryption format is used across all Nift integration paths:
 
@@ -236,9 +236,9 @@ public String encryptValue(String value, String base64Key) throws Exception {
 
 </details>
 
-## Encrypting Multiple Fields (`customer_data`)
+## Encrypting Multiple Fields (`enc`)
 
-The `customer_data` parameter lets you encrypt multiple customer fields in a single blob. The process is the same as above, except the **plaintext** you encrypt is a JSON string instead of a raw value.
+The `enc` parameter lets you encrypt multiple customer fields in a single blob. The process is the same as above, except the **plaintext** you encrypt is a JSON string instead of a raw value.
 
 ### Supported fields
 
@@ -264,7 +264,7 @@ The `customer_data` parameter lets you encrypt multiple customer fields in a sin
 
 2. Treat this JSON **string** as the plaintext and follow the same [encryption steps above](#how-to-encrypt).
 
-3. Pass the result as the `customer_data` query parameter.
+3. Pass the result as the `enc` query parameter.
 
 For example, using the Python function from the code examples:
 
@@ -279,7 +279,7 @@ customer_fields = json.dumps({
 })
 
 encrypted = encrypt_value(customer_fields, base64_key)
-# Use as: ?customer_data={encrypted}
+# Use as: ?enc={encrypted}
 ```
 
 For full usage details, see [Encrypted Customer Data in the Nift Web Flow](encrypted_customer_data_web_flow.md).
@@ -287,7 +287,7 @@ For full usage details, see [Encrypted Customer Data in the Nift Web Flow](encry
 ## Important Notes
 
 *   **Never reuse an IV** with the same key. Generate a fresh random 12-byte IV for every encryption.
-*   **Plaintext fallback (email only)**: If you send an unencrypted email (containing `@`) via the `email` parameter, it will be accepted as-is. This allows gradual rollout. This does **not** apply to `customer_data`, which is always treated as encrypted.
+*   **Plaintext fallback (email only)**: If you send an unencrypted email (containing `@`) via the `email` parameter, it will be accepted as-is. This allows gradual rollout. This does **not** apply to `enc`, which is always treated as encrypted.
 *   **Plaintext detection**: The `@` character is not part of Base64 or Base64url, so the system reliably distinguishes plaintext email addresses from encrypted blobs by checking for the presence of `@`.
 *   **Tag length**: Always use a 128-bit (16-byte) authentication tag. This is the GCM default and maximum.
 *   **No padding characters**: Base64url encoding should NOT include `=` padding characters.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,11 +15,13 @@ Nift provides SDKs for partners to integrate the Nift gift redemption flow direc
 
 [Customer Status Server API](sdk/customer-status-server.md) - Backend API integration
 
-## Encrypted Email
+## Encryption
 
 ---
 [Encrypting Values](encrypting_values.md) - How to encrypt sensitive fields with AES-256-GCM
 
-[Nift Web Flow](encrypted_email_web_flow.md) - Passing encrypted email via referral links
+[Nift Web Flow — Encrypted Email](encrypted_email_web_flow.md) - Passing encrypted email via referral links
+
+[Nift Web Flow — Encrypted Customer Data](encrypted_customer_data_web_flow.md) - Passing multiple encrypted fields via referral links
 
 [Nift SDK](encrypted_email_sdk.md) - Passing encrypted email via SDKs


### PR DESCRIPTION
Instructions for how to securely send customer data to Nift for full form pre-pop.